### PR TITLE
Add script to package plugin and create release

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ You can make a [pull request](https://github.com/SilentVoid13/Templater/pulls) t
 
 Check [this](https://silentvoid13.github.io/Templater/internal-functions/contribute.html) to get more information on how to develop a new internal variable / function.
 
+## Build & Release
+
+Run `pnpm create-release` to build the plugin and package the distributable files into a zip archive. If the [GitHub CLI](https://cli.github.com/) is installed and authenticated, the script will also create a release for the current version.
+
 ## License
 
 [Templater](https://github.com/SilentVoid13/Templater) is licensed under the GNU AGPLv3 license. Refer to [LICENSE](https://github.com/SilentVoid13/Templater/blob/master/LICENSE.TXT) for more information.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "test-dev": "node esbuild.config.mjs test",
         "docs-dev": "mdbook serve docs",
         "commit": "cz",
+        "create-release": "node scripts/create-release.cjs",
         "release": "standard-version -t ''"
     },
     "keywords": [

--- a/scripts/create-release.cjs
+++ b/scripts/create-release.cjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..');
+function run(cmd) {
+    execSync(cmd, { stdio: 'inherit', cwd: rootDir });
+}
+
+// Build the plugin
+run('pnpm build');
+
+// Read version from manifest
+const manifest = JSON.parse(fs.readFileSync(path.join(rootDir, 'manifest.json'), 'utf8'));
+const version = manifest.version;
+
+// Prepare release directory
+const releaseDir = path.join(rootDir, 'release');
+if (!fs.existsSync(releaseDir)) {
+    fs.mkdirSync(releaseDir);
+}
+const zipPath = path.join(releaseDir, `templater-${version}.zip`);
+
+// Package plugin files
+run(`zip -r ${zipPath} manifest.json main.js styles.css`);
+
+// Try creating a GitHub release using the GitHub CLI
+try {
+    run(`gh release create v${version} ${zipPath} -t \"v${version}\"`);
+} catch (err) {
+    console.log('GitHub release skipped. Ensure GitHub CLI is installed and authenticated.');
+    console.log(`Created ${zipPath}`);
+}


### PR DESCRIPTION
## Summary
- add `create-release` script to build plugin, zip output and optionally publish a GitHub release
- expose `create-release` through npm scripts and document release workflow

## Testing
- ❌ `pnpm pretest` (5 ESLint errors)
- ✅ `pnpm test-build`
- ⚠️ `pnpm create-release` (GitHub CLI missing; zip generated)


------
https://chatgpt.com/codex/tasks/task_e_68a6e0e1e72c83308c7559a1928416a1