### PR TITLE
Fix arraymove utility to reposition items correctly

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -166,12 +166,17 @@ export function arraymove<T>(
     fromIndex: number,
     toIndex: number
 ): void {
-    if (toIndex < 0 || toIndex === arr.length) {
+    if (
+        fromIndex < 0 ||
+        fromIndex >= arr.length ||
+        toIndex < 0 ||
+        toIndex >= arr.length ||
+        fromIndex === toIndex
+    ) {
         return;
     }
-    const element = arr[fromIndex];
-    arr[fromIndex] = arr[toIndex];
-    arr[toIndex] = element;
+    const [element] = arr.splice(fromIndex, 1);
+    arr.splice(toIndex, 0, element);
 }
 
 export function get_active_file(app: App) {

--- a/tests/arraymove.test.js
+++ b/tests/arraymove.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const Module = require('module');
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function(id) {
+  if (id === 'obsidian') return { TFile: class {}, Notice: class {} };
+  return originalRequire.apply(this, arguments);
+};
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({ module: 'commonjs' });
+require('ts-node/register/transpile-only');
+const { arraymove } = require('../src/utils/Utils');
+
+const arr = [1,2,3,4];
+arraymove(arr,0,2);
+assert.deepStrictEqual(arr,[2,3,1,4]);
+
+const arr2 = [1,2,3,4];
+arraymove(arr2,3,0);
+assert.deepStrictEqual(arr2,[4,1,2,3]);
+
+console.log('arraymove tests passed');


### PR DESCRIPTION
## Summary
- Fix `arraymove` to relocate elements instead of swap
- Add unit test verifying correct array movement

## Testing
- `node tests/arraymove.test.js`
- `npm run pretest` *(fails: Don't use `Object` as a type, `'window' is not defined`, `'DocParamBlock' is defined but never used`, `'ParserContext' is defined but never used`)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dcecbb508330ba12fed606c6beac